### PR TITLE
docs: [#5] add Netlify status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 The Engine House blog.
 
+[![Netlify Status](https://api.netlify.com/api/v1/badges/f64b575a-550f-4645-8535-9916a973ac95/deploy-status)](https://app.netlify.com/sites/pedantic-lewin-8625f2/deploys)
+
 To generate output use stdin and stdout.
 
 For example:


### PR DESCRIPTION
Closes #5

## Acceptance Criteria

- the Netlify status badge is visible in the README

<img width="947" alt="Screenshot 2022-02-13 at 14 42 14" src="https://user-images.githubusercontent.com/62572/153758381-46651bb7-a6e9-42ec-b58b-9c0e5b569366.png">